### PR TITLE
Replace uses of __UINTCAP_WIDTH__.

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -55,14 +55,14 @@ public:
 
 #if USE(JSVALUE64)
 #if defined(__CHERI_PURE_CAPABILITY__) && ENABLE(JSHEAP_CHERI_OFFSET_REFS)
-#if __UINTCAP_WIDTH__ == 128
-    static constexpr ptrdiff_t CallFrameHeaderSlots = 7;
-#else // __UINTCAP_WIDTH__ != 128
-    static constexpr ptrdiff_t CallFrameHeaderSlots = 11;
-#endif // __UINTCAP_WIDTH__ != 128
+    // sizeof(CPURegister) == __SIZEOF_UINTCAP__
+    // sizeof(Register) == 8
+    static constexpr ptrdiff_t CallFrameHeaderSlots = (2 * __SIZEOF_UINTCAP__ / 8) + 3;
 #else // !__CHERI_PURE_CAPABILITY__ || !ENABLE(JSHEAP_CHERI_OFFSET_REFS)
+    // sizeof(CPURegister) == sizeof(Register), so the number of slots is fixed,
+    // even though the slot size depends on __CHERI_PURE_CAPABILITY__.
     static constexpr ptrdiff_t CallFrameHeaderSlots = 5;
-#endif // !__CHERI_PURE_CAPABILITY__ || !ENABLE(JSHEAP_CHERI_OFFSET_REFS)
+#endif
 #else // !USE(JSVALUE64) // i.e. 32-bit version
     const ptrdiff_t CallFrameHeaderSlots = 4;
 #endif // !USE(JSVALUE64)

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -57,7 +57,7 @@ public:
 #if defined(__CHERI_PURE_CAPABILITY__) && ENABLE(JSHEAP_CHERI_OFFSET_REFS)
     // sizeof(CPURegister) == __SIZEOF_UINTCAP__
     // sizeof(Register) == 8
-    static constexpr ptrdiff_t CallFrameHeaderSlots = (2 * __SIZEOF_UINTCAP__ / 8) + 3;
+    static constexpr ptrdiff_t CallFrameHeaderSlots = (2 * __SIZEOF_INTCAP__ / 8) + 3;
 #else // !__CHERI_PURE_CAPABILITY__ || !ENABLE(JSHEAP_CHERI_OFFSET_REFS)
     // sizeof(CPURegister) == sizeof(Register), so the number of slots is fixed,
     // even though the slot size depends on __CHERI_PURE_CAPABILITY__.

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -55,7 +55,7 @@ public:
 
 #if USE(JSVALUE64)
 #if defined(__CHERI_PURE_CAPABILITY__) && ENABLE(JSHEAP_CHERI_OFFSET_REFS)
-    // sizeof(CPURegister) == __SIZEOF_UINTCAP__
+    // sizeof(CPURegister) == __SIZEOF_INTCAP__
     // sizeof(Register) == 8
     static constexpr ptrdiff_t CallFrameHeaderSlots = (2 * __SIZEOF_INTCAP__ / 8) + 3;
 #else // !__CHERI_PURE_CAPABILITY__ || !ENABLE(JSHEAP_CHERI_OFFSET_REFS)

--- a/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
+++ b/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
@@ -38,14 +38,16 @@
 #endif
 
 #ifdef __CHERI_PURE_CAPABILITY__
-#if __UINTCAP_WIDTH__ == 128
+#ifndef __SIZEOF_INTCAP__
+#error __SIZEOF_INTCAP__ is undefined
+#elif __SIZEOF_INTCAP__ == 16
 #define OFFLINE_ASM_CHERI_128_PURECAP 1
 #define OFFLINE_ASM_CHERI_256_PURECAP 0
-#elif __UINTCAP_WIDTH__ == 256
+#elif __SIZEOF_INTCAP__ == 32
 #define OFFLINE_ASM_CHERI_128_PURECAP 0
 #define OFFLINE_ASM_CHERI_256_PURECAP 1
 #else
-#error __UINTCAP_WIDTH__ is undefined or an unsupported value
+#error __SIZEOF_INTCAP__ has an unsupported value
 #endif
 #else
 #define OFFLINE_ASM_CHERI_128_PURECAP 0


### PR DESCRIPTION
__UINTCAP_WIDTH__ was removed from LLVM in c0c99e7671.