### PR TITLE
fix slowpath flow in FreeListInlines.h

### DIFF
--- a/Source/JavaScriptCore/heap/FreeListInlines.h
+++ b/Source/JavaScriptCore/heap/FreeListInlines.h
@@ -52,7 +52,7 @@ ALWAYS_INLINE HeapCell* FreeList::allocate(const Func& slowPath)
 #ifdef __CHERI_PURE_CAPABILITY__
         ret = cheri_setboundsexact(ret, m_cellSize);
 #endif
-        return slowPath();
+        return ret;
     }
     
     m_scrambledHead = result->scrambledNext;


### PR DESCRIPTION
In the function FreeList::allocate, there is a subflow that calls slowPath() and store the result in ret. Then, instead of return ret, it calls slowPath agains and return that. That's a bug in CHERI (the capability won't have exact bounds), and in general, leaks allocation :)