### PR TITLE
Fix ContinuousArenaMalloc

### DIFF
--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -168,12 +168,12 @@ void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
     if (new_addr != NULL || size == 0) {
         ret = NULL;
     } else {
-        s_Current = __builtin_align_up(s_Current, alignment);
+        char *start = __builtin_align_up(s_Current, alignment);
 
-        if (!isValidRange(s_Current, size)) {
+        if (!isValidRange(start, size)) {
             ret = NULL;
         } else {
-            ret = mmap(s_Current,
+            ret = mmap(start,
                        size,
                        PROT_READ | PROT_WRITE,
                        MAP_ANON | MAP_PRIVATE | MAP_FIXED,
@@ -183,13 +183,13 @@ void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
                 ret = NULL;
             } else {
 #ifdef __CHERI_PURE_CAPABILITY__
-                ASSERT(__builtin_cheri_address_get(ret) == __builtin_cheri_address_get(s_Current));
+                ASSERT(__builtin_cheri_address_get(ret) == __builtin_cheri_address_get(start));
 #endif
 
                 *zero = true;
                 *commit = true;
 
-                s_Current += size;
+                s_Current = start + size;
             }
         }
     }

--- a/Source/WTF/wtf/ContinuousArenaMalloc.h
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.h
@@ -131,7 +131,13 @@ private:
     static void* internalReallocate(void *p, size_t size);
     static void internalFree(void* ptr);
 
+    // True iff [addr, addr+size) is a subset of or equal to [s_Start, s_End).
     static bool isValidRange(void *addr, size_t size);
+    // True iff [addr, addr+size) is a subset of or equal to [s_Start, s_Current).
+    static bool isAllocatedRange(void *addr, size_t size);
+    // True iff [addr, addr+size) is a subset of or equal to [s_Current, s_End).
+    static bool isAvailableRange(void *addr, size_t size);
+
     static void* extentAlloc(extent_hooks_t *extent_hooks,
                              void *new_addr,
                              size_t size,

--- a/Source/WTF/wtf/ContinuousArenaMalloc.h
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.h
@@ -145,28 +145,17 @@ private:
                              bool *zero,
                              bool *commit,
                              unsigned arena_ind);
-    static bool extentDalloc(extent_hooks_t *extent_hooks,
-                             void *addr,
-                             size_t size,
-                             bool committed,
-                             unsigned arena_ind);
     static void extentDestroy(extent_hooks_t *extent_hooks,
                               void *addr,
                               size_t size,
                               bool committed,
                               unsigned arena_ind);
-    static bool extentCommit(extent_hooks_t *extent_hooks,
-                             void *addr,
-                             size_t size,
-                             size_t offset,
-                             size_t length,
-                             unsigned arena_ind);
-    static bool extentDecommit(extent_hooks_t *extent_hooks,
-                               void *addr,
-                               size_t size,
-                               size_t offset,
-                               size_t length,
-                               unsigned arena_ind);
+    static bool extentPurgeCommon(extent_hooks_t *extent_hooks,
+                                  void *addr,
+                                  size_t size,
+                                  size_t offset,
+                                  size_t length,
+                                  unsigned arena_ind);
     static bool extentPurgeLazy(extent_hooks_t *extent_hooks,
                                 void *addr,
                                 size_t size,
@@ -179,20 +168,6 @@ private:
                                   size_t offset,
                                   size_t length,
                                   unsigned arena_ind);
-    static bool extentSplit(extent_hooks_t *extent_hooks,
-                            void *addr,
-                            size_t size,
-                            size_t size_a,
-                            size_t size_b,
-                            bool committed,
-                            unsigned arena_ind);
-    static bool extentMerge(extent_hooks_t *extent_hooks,
-                            void *addr_a,
-                            size_t size_a,
-                            void *addr_b,
-                            size_t size_b,
-                            bool committed,
-                            unsigned arena_ind);
 
     static bool s_Initialized;
     static unsigned int s_arenaIndex;


### PR DESCRIPTION
Fix a couple of minor bugs in `ContinuousArenaMalloc`, and clean up a bit at the same time. Notably:

* Make `isValidRange` respect its inputs.
* Ensure that extent allocation requests unrepresentable by a capability are properly handled.