### PR TITLE
CHERI: Use __has_feature() consistently.

### DIFF
--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -106,7 +106,7 @@ TextStream& TextStream::operator<<(double d)
     return *this;
 }
 
-#ifdef __CHERI__
+#if __has_feature(capabilities)
 TextStream& TextStream::operator<<(__intcap_t i)
 {
     m_text.appendNumber(__builtin_cheri_address_get(i));

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -67,7 +67,7 @@ public:
     WTF_EXPORT_PRIVATE TextStream& operator<<(unsigned long long);
     WTF_EXPORT_PRIVATE TextStream& operator<<(float);
     WTF_EXPORT_PRIVATE TextStream& operator<<(double);
-#ifdef __CHERI__
+#if __has_feature(capabilities)
     WTF_EXPORT_PRIVATE TextStream& operator<<(__intcap_t);
 #endif
     WTF_EXPORT_PRIVATE TextStream& operator<<(const char*);


### PR DESCRIPTION
This is the idiomatic way to test for CHERI (hybrid or purecap) support,
rather than `__CHERI__`.